### PR TITLE
Updating import ref for osext to new github repo

### DIFF
--- a/logging/fields.go
+++ b/logging/fields.go
@@ -17,7 +17,7 @@
 package logging
 
 import (
-	"bitbucket.org/kardianos/osext"
+	"github.com/kardianos/osext"
 	"os"
 	"path"
 	"runtime"


### PR DESCRIPTION
The osext library was moved to Github at the end of February.